### PR TITLE
Fix to Mysql 8 issue with UTF8 <> BINARY comparison

### DIFF
--- a/app/models/redirect_rule.rb
+++ b/app/models/redirect_rule.rb
@@ -24,7 +24,7 @@ class RedirectRule < ActiveRecord::Base
 
   def self.regex_expression
     if connection_mysql?
-      '(redirect_rules.source_is_case_sensitive = :true AND :source REGEXP BINARY redirect_rules.source) OR '+
+      '(redirect_rules.source_is_case_sensitive = :true AND CAST(:source AS BINARY) REGEXP BINARY redirect_rules.source) OR '+
       '(redirect_rules.source_is_case_sensitive = :false AND :source REGEXP redirect_rules.source)'
     elsif connection_sqlite?
       '(redirect_rules.source_is_case_sensitive = :true AND :source REGEXP redirect_rules.source COLLATE BINARY) OR '+


### PR DESCRIPTION
fixes an issue in in Mysql 8.0.23 where string comparison from utf8_general_ci to BINARY isnt possible 

> Mysql2::Error: Character set 'utf8_general_ci' cannot be used in conjunction with 'binary' in call to regexp_like